### PR TITLE
Receipt urlencode fix

### DIFF
--- a/src/Robokassa.php
+++ b/src/Robokassa.php
@@ -163,8 +163,8 @@ class Robokassa
         }
 
         if (!empty($params['Receipt'])) {
-            $params['Receipt'] = urlencode(json_encode($params['Receipt']));
-            $signatureParams['Receipt'] = $params['Receipt'];
+            $signatureParams['Receipt'] = urlencode($params['Receipt']);
+            $params['Receipt'] = urlencode($signatureParams['Receipt']);
         }
 
         if (!empty($params['IsTest']) && $params['IsTest']) {

--- a/src/Robokassa.php
+++ b/src/Robokassa.php
@@ -163,7 +163,7 @@ class Robokassa
         }
 
         if (!empty($params['Receipt'])) {
-            $signatureParams['Receipt'] = urlencode($params['Receipt']);
+            $signatureParams['Receipt'] = urlencode(json_encode($params['Receipt']));
             $params['Receipt'] = urlencode($signatureParams['Receipt']);
         }
 


### PR DESCRIPTION
Исправлен алгоритм кодирования информации для чека.
Сделано двойное url кодирование для передаваемой строки. Не документировано, но информация от ТП Робокассы и по итогу чек удалось пробить.